### PR TITLE
Fix typo in @exercises/3d-clear-depth.

### DIFF
--- a/exercises/3d-clear-depth/solution/setup.js
+++ b/exercises/3d-clear-depth/solution/setup.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 
 var VERT_SRC = fs.readFileSync(__dirname + '/shader.vert', 'utf8')
-var FRAG_SRC = fs.readFileSYnc(__dirname + '/shader.frag', 'utf8')
+var FRAG_SRC = fs.readFileSync(__dirname + '/shader.frag', 'utf8')
 
 function compileShader(gl, type, src) {
   var shader = gl.createShader(type)

--- a/exercises/3d-clear-depth/submission/setup.js
+++ b/exercises/3d-clear-depth/submission/setup.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 
 var VERT_SRC = fs.readFileSync(__dirname + '/shader.vert', 'utf8')
-var FRAG_SRC = fs.readFileSYnc(__dirname + '/shader.frag', 'utf8')
+var FRAG_SRC = fs.readFileSync(__dirname + '/shader.frag', 'utf8')
 
 function compileShader(gl, type, src) {
   var shader = gl.createShader(type)


### PR DESCRIPTION
Fixes this error on /@exercise/3d-clear-depth/:

```
Cannot call method 'apply' of undefined while parsing file: /home/zach/code/webgl-workshop/answers/3d-clear-depth/setup.js
TypeError: Cannot call method 'apply' of undefined while parsing file: /home/zach/code/webgl-workshop/answers/3d-clear-depth/setup.js
    at walk (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/static-eval/index.js:89:27)
    at module.exports (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/static-eval/index.js:114:7)
    at traverse (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/index.js:295:23)
    at walk (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/index.js:226:18)
    at walk (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/falafel/index.js:58:9)
    at /usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/falafel/index.js:55:17
    at Array.forEach (native)
    at forEach (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/falafel/index.js:9:31)
    at walk (/usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/falafel/index.js:43:9)
    at /usr/lib/node_modules/webgl-workshop/node_modules/brfs/node_modules/static-module/node_modules/falafel/index.js:55:17
```