### PR TITLE
Fix Typo in @examples/texture-create.

### DIFF
--- a/exercises/texture-create/README.md
+++ b/exercises/texture-create/README.md
@@ -43,7 +43,7 @@ After the texture is bound, we can then configure various options on the texture
 
 ```javascript
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+gl.texParameterf(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
 ```
 
 # Uploading Image Data


### PR DESCRIPTION
Replaced `gl.texParameteri` by `gl.texParameterf`