### PR TITLE
Adds `gl.useProgram(program)` to initial file

### DIFF
--- a/exercises/shader-uniforms/submission/index.js
+++ b/exercises/shader-uniforms/submission/index.js
@@ -28,6 +28,7 @@ exports.draw = function(gl) {
   gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight)
   gl.clearColor(0,0,0,1)
   gl.clear(gl.COLOR_BUFFER_BIT)
+  gl.useProgram(program)
 
   //TODO: Draw the triangles with the shader/uniforms
 }


### PR DESCRIPTION
Without, the console fills up with cryptic "WebGL: INVALID_OPERATION: uniform3fv: location is not from current program" errors. 