### PR TITLE
Fixed the creation of the workshop archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ pack:
 	npm dedupe
 	cp package.json _package.json
 	node lib/pack
-	find . -type file \
+	find -L . -type file \
 		| grep -v ./app/ \
 		| grep -v ./.git/ \
 		| grep -v ./docs/ \
@@ -24,7 +24,7 @@ pack:
 		| grep -v ./_package.json \
 		| grep -v ./Makefile \
 		| grep -v workshop.tar.gz \
-		| grep -v ./node_modules/[^@] \
+		| grep -Ev "./node_modules/[^@]" \
 		| tar -cvzf workshop.tar.gz -T -
 	mv _package.json package.json
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "contributors": [
     "Mikola Lysenko",
-    "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)"
+    "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",
+    "Philipp Beau <philippb3au@gmail.com> (https://dathuis.nl/)"
   ],
   "scripts": {
     "start": "node node.js",


### PR DESCRIPTION
`find -L` makes find resolve symlinks 
`"grep -Ev "./node_modules/[^@]"` use regex which works on OSX